### PR TITLE
[hotfix] Fix datepicker

### DIFF
--- a/utils/date.js
+++ b/utils/date.js
@@ -9,7 +9,7 @@ export const getFormattedDate = (dateString) => {
 
 export const getMaxMinDate = (startDate = "", amountOfDays) => {
   const [year, month, day] = startDate.split("-");
-  const newDate = new Date(year, month, day);
+  const newDate = new Date(year, month - 1, day);
 
   newDate.setDate(newDate.getDate() + amountOfDays);
 


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR fixes an issue with the `getMaxMinDate()` function, which was incorrectly changing the month when passed a certain date. The problem was caused by passing the month value as a base-zero number, resulting in the function interpreting the month as the previous one.