### PR TITLE
[CROW-223] Add use-click-away library to handle dropdowns

### DIFF
--- a/components/dropdown/dropdown.js
+++ b/components/dropdown/dropdown.js
@@ -1,5 +1,6 @@
 import Image from "next/image";
-import { useState } from "react";
+import { useState, useRef } from "react";
+import { useClickAway } from "use-click-away";
 
 import downArrow from "assets/icons/downArrow.svg";
 
@@ -16,10 +17,15 @@ import {
 export const Dropdown = ({ options, handleSelect, label, isLoading }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState(null);
+  const clickRef = useRef("");
 
   const handleButtonClick = () => {
     setIsOpen((prev) => !prev);
   };
+
+  useClickAway(clickRef, () => {
+    setIsOpen(false);
+  });
 
   const handleOptionClick = (option) => {
     setSelectedOption(option.symbol);
@@ -30,7 +36,7 @@ export const Dropdown = ({ options, handleSelect, label, isLoading }) => {
   if (isLoading)
     return (
       <div>
-        <Label htmlFor="dropdown">{label}</Label>
+        <Label>{label}</Label>
         <Container>
           <Skeleton />
         </Container>
@@ -49,7 +55,7 @@ export const Dropdown = ({ options, handleSelect, label, isLoading }) => {
         </Wrapper>
 
         {isOpen && (
-          <DropdownList>
+          <DropdownList ref={clickRef}>
             {options.map((option) => (
               <DropdownItem
                 key={option.symbol}

--- a/components/header/header.js
+++ b/components/header/header.js
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useRouter } from "next/router";
+import { useClickAway } from "use-click-away";
 
 import smallLogo from "assets/small-logo.svg";
 import { useHasMounted } from "hooks/useHasMounted";
@@ -26,9 +27,14 @@ import {
 export const Header = () => {
   const router = useRouter();
   const hasMounted = useHasMounted();
+  const clickRef = useRef("");
   const { logout, isUserAuthenticated } = useAuth();
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  useClickAway(clickRef, () => {
+    setIsDropdownOpen(false);
+  });
 
   const onLogOut = () => {
     logout();
@@ -65,7 +71,7 @@ export const Header = () => {
               </HeaderText>
             </DropdownButton>
             {isDropdownOpen && (
-              <DropdownContent>
+              <DropdownContent ref={clickRef}>
                 {HEADER_DROPDOWN_ITEMS.map((item) => (
                   <Link href={item.link} key={item.link}>
                     <HeaderText>{item.title}</HeaderText>

--- a/components/modal/modal.styles.js
+++ b/components/modal/modal.styles.js
@@ -29,8 +29,7 @@ export const ToastContent = styled.div`
   gap: 4px;
 
   p {
-    margin: 0px;
-    margin-left: 33px;
+    margin: 0 0 10px 33px;
   }
 `;
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-hook-form": "^7.37.0",
     "react-modal": "^3.16.1",
     "react-toastify": "^9.1.2",
+    "use-click-away": "^0.0.1",
     "wagmi": "^0.7.4",
     "yup": "^0.32.11"
   },

--- a/pages/create/index.page.js
+++ b/pages/create/index.page.js
@@ -44,6 +44,7 @@ const Create = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { isUserAuthenticated, accessToken } = useAuth();
   const router = useRouter();
+
   const { data: tokens, isLoading: isTokensLoading } = useQuery(
     [QUERIES.tokens, accessToken],
     () => fetchTokens(accessToken)

--- a/utils/fetch.js
+++ b/utils/fetch.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { ACCESS_TOKEN } from "../constants";
 
 export const fetchCampaigns = async (activePage, search) => {
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6067,6 +6067,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-click-away@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/use-click-away/-/use-click-away-0.0.1.tgz#43aa5cda250e0d05d7f9006e39430a72a7c042bb"
+  integrity sha512-s6ntmDs4XaMTi1zl4sXL8zGb9505L5jkV+KqYpwEU6r89YBkZlpie99Cg7t9z3ScVUxUYk53EvV/6UAO2Co2nQ==
+
 use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"


### PR DESCRIPTION
#### :page_facing_up: Description:

In this PR the use-click-away library is added to improve the UX. What this library does is to close the dropdowns when the user clicks outside the dropdown. In addition, the toast styles are adjusted and an import that was not being used in the file called fetch is deleted.

