### PR TITLE
[CROW-252] Fix useQuery call to only excecute fetchCampaign when id is defined

### DIFF
--- a/pages/project/[id].page.js
+++ b/pages/project/[id].page.js
@@ -44,8 +44,10 @@ const ProjectPage = () => {
     mode: "onChange",
   });
 
-  const { data, isLoading } = useQuery([QUERIES.campaign, id], () =>
-    fetchCampaign(id)
+  const { data, isLoading } = useQuery(
+    [QUERIES.campaign, id],
+    () => fetchCampaign(id),
+    { enabled: Boolean(id) }
   );
 
   const { onSubmit, isTransactionComplete } = usePledge(


### PR DESCRIPTION
#### :page_facing_up: Description:

Modified the useQuery configuration in the ProjectPage component to ensure that the fetchCampaign function is only executed when the 'id' parameter is defined. This prevents the function from being called with an undefined 'id' value during the first render.

